### PR TITLE
Updated and optimized resource type list for "biff all" option

### DIFF
--- a/generalized_biffing/lib/main_component.tpa
+++ b/generalized_biffing/lib/main_component.tpa
@@ -25,7 +25,7 @@ OUTER_TEXT_SPRINT ~9char~ ~%char%%char%%char%%char%%char%%char%%char%%char%%char
 OUTER_TEXT_SPRINT ~ext~ ~\(wav\|tis\|bam\)~
 ACTION_IF biffing_all BEGIN
   ACTION_IF ENGINE_IS ~bgee bg2ee iwdee pstee~ BEGIN
-    OUTER_TEXT_SPRINT ee_types ~\|fnt\|glsl\|gui\|lua\|maze\|menu\|png\|pvrz\|sql\|ttf\|wbm~
+    OUTER_TEXT_SPRINT ee_types ~\|fnt\|glsl\|gui\|lua\|menu\|png\|pvrz\|sql\|ttf\|wbm~
   END ELSE BEGIN
     OUTER_TEXT_SPRINT ee_types ~~
   END

--- a/generalized_biffing/lib/main_component.tpa
+++ b/generalized_biffing/lib/main_component.tpa
@@ -24,7 +24,12 @@ OUTER_TEXT_SPRINT ~8char~ ~%char%%char%?%char%?%char%?%char%?%char%?%char%?%char
 OUTER_TEXT_SPRINT ~9char~ ~%char%%char%%char%%char%%char%%char%%char%%char%%char%%char%*~
 OUTER_TEXT_SPRINT ~ext~ ~\(wav\|tis\|bam\)~
 ACTION_IF biffing_all BEGIN
-	OUTER_TEXT_SPRINT ext ~\(bmp\|mve\|wav\|wfx\|plt\|bam\|wed\|chu\|tis\|mos\|itm\|spl\|bcs\|ids\|cre\|are\|dlg\|2da\|gam\|sto\|wmp\|eff\|chr\|vvc\|vef\|pro\|wbm\|fnt\|gui\|sql\|pvrz\|glsl\|ini\)~
+  ACTION_IF ENGINE_IS ~bgee bg2ee iwdee pstee~ BEGIN
+    OUTER_TEXT_SPRINT ee_types ~\|fnt\|glsl\|gui\|lua\|maze\|menu\|png\|pvrz\|sql\|ttf\|wbm~
+  END ELSE BEGIN
+    OUTER_TEXT_SPRINT ee_types ~~
+  END
+	OUTER_TEXT_SPRINT ext ~\(2da\|are\|bam\|bcs\|bmp\|chr\|chu\|cre\|dlg\|eff\|gam\|ids\|ini\|itm\|mos\|mve\|plt\|pro\|spl\|sto\|tis\|vef\|vvc\|wav\|wed\|wfx\|wmp%ee_types%\)~
 END
 
 OUTER_TEXT_SPRINT ~myRegExp~ ~^%8char%\.%ext%$~


### PR DESCRIPTION
- Added missing EE-specific resource types: LUA, MENU, PNG and TTF
- EE-specific resource types are only considered for EE games
- Sorted resource type list alphabetically
